### PR TITLE
Fix type in docker exec command

### DIFF
--- a/bin/hello-world
+++ b/bin/hello-world
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-exec docker --log-level warn run -t --rm hello-world "$@"
+docker exec --log-level warn run -t --rm hello-world "$@"


### PR DESCRIPTION
Is this what the original implementation was supposed to be?